### PR TITLE
fix: compressImage canvas: true 옵션 추가

### DIFF
--- a/.changeset/true-clubs-look.md
+++ b/.changeset/true-clubs-look.md
@@ -1,0 +1,5 @@
+---
+'@croquiscom/monolith': patch
+---
+
+compressImage canvas option이 없어서 리사이징이 안되는 문제 수정

--- a/src/utils/compress-image/compressImage.ts
+++ b/src/utils/compress-image/compressImage.ts
@@ -69,6 +69,7 @@ export async function compressImage(file: File, max_width?: number): Promise<Fil
         },
         {
           maxWidth: max_width ?? 375,
+          canvas: true,
         },
       );
     } catch (e) {


### PR DESCRIPTION
## 작업내역
- compressImage canvas: true 옵션이 없어서 이미지 수정이 안되고 있어서 이를 수정합니다.
## 고민사항 / 중점적으로 리뷰받고 싶은 부분

## 꼭 확인해주세요

- PR 작성자
  - 자체테스트 혹은 QA 가 완료되었나요?
  - 서버 배포 필요여부 및 배포 순서를 확인하였나요?
  - Squash merge를 해주세요
  - 리뷰 대응중인 경우 PR의 상태를 꼭 `draft`로 변경해주세요
  - 코드 설명이 필요하다 싶은 부분은 `comment`를 통해 설명을 붙여주세요
  - 테스트 코드를 테스트 하기 위해서는 `test`라벨을 붙여서 PR을 생성 해주세요
- 리뷰어
  - 꼭 반영해주었으면 하는 부분은 `request change`로 남겨주세요
  - 리뷰 전에 확인이 필요하거나 궁금한 부분은 `comment`로 남겨주세요
  - 반영되면 좋지만 꼭 반영되지 않아도 되는 코멘트인 경우에는 `approve`로 남겨주세요
