### PR TITLE
feat: debounce 처리용 util 및 hook 구현

### DIFF
--- a/.changeset/busy-states-sink.md
+++ b/.changeset/busy-states-sink.md
@@ -1,0 +1,5 @@
+---
+'@croquiscom/monolith': minor
+---
+
+debounce 처리용 util 및 hook 추가

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -7,3 +7,4 @@ export { useIsMounted } from './use-is-mounted/useIsMounted';
 export { usePreloadImage } from './use-preload-image/usePreloadImage';
 export { useCountDownTimer } from './use-countdown-timer/useCountDownTimer';
 export { useIsomorphicLayoutEffect } from './use-isomorphic-layout-effect/useIsomorphicLayoutEffect';
+export { useDebounce } from './use-debounce/useDebounce';

--- a/src/hooks/use-debounce/useDebounce.test.ts
+++ b/src/hooks/use-debounce/useDebounce.test.ts
@@ -1,0 +1,86 @@
+import { renderHook } from '@testing-library/react';
+import { useDebounce } from './useDebounce';
+
+describe('useDebounce', () => {
+  const wait = 100;
+  let func = vi.fn();
+
+  beforeAll(() => {
+    vi.useFakeTimers();
+  });
+
+  beforeEach(() => {
+    func = vi.fn();
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  it('invoke_edge 가 "trailing" 일 경우, 지연 시간 이후에 함수가 호출 됩니다.', () => {
+    const { result } = renderHook(() =>
+      useDebounce({
+        func,
+        wait,
+        invoke_edge: 'trailing',
+      }),
+    );
+
+    result.current();
+    result.current();
+    expect(func).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(100);
+
+    expect(func).toHaveBeenCalledTimes(1);
+  });
+
+  it('invoke_edge 가 "leading" 일 경우, 함수가 즉시 호출 됩니다.', () => {
+    const { result } = renderHook(() =>
+      useDebounce({
+        func,
+        wait,
+        invoke_edge: 'leading',
+      }),
+    );
+
+    result.current();
+    expect(func).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(50);
+
+    result.current();
+    expect(func).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(100);
+
+    result.current();
+    expect(func).toHaveBeenCalledTimes(2);
+  });
+
+  it('지연 시간 내에 호출이 발생 하면 타이머가 리셋 됩니다.', () => {
+    const { result } = renderHook(() =>
+      useDebounce({
+        func,
+        wait,
+        invoke_edge: 'trailing',
+      }),
+    );
+
+    result.current();
+    expect(func).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(50);
+
+    result.current();
+    expect(func).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(50);
+
+    expect(func).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(50);
+
+    expect(func).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/use-debounce/useDebounce.ts
+++ b/src/hooks/use-debounce/useDebounce.ts
@@ -17,13 +17,13 @@ interface Config<T extends AnyFunc> {
  * "trailing" 일 경우, 가장 마지막 호출 시점으로부터 지연 시간이 모두 흐른 뒤에 함수가 호출 됩니다.
  * "leading" 일 경우 함수를 즉시 호출하고, 지연 시간동안 추가적인 호출을 차단합니다.
  *
- * 한편, 리턴된 함수는 memoized 되어 있습니다.
+ * 리턴된 함수는 memo 처리 되어 있습니다.
  *
- * @param func {Function} - 지연 효과를 적용할 함수
- * @param wait {number} - [wait=0] 지연 시간(ms 단위)
- * @param invoke_edge {"leading" | "trailing"} - [invoke_edge="trailing"] 함수 호출 시점.
- * leading 일 경우 지연 시작 지점에 함수를 호출 합니다.
- * trailing 일 경우
+ * @param config debounce 설정 객체
+ * @param config.func 지연 효과를 적용할 함수
+ * @param config.wait 지연 시간(ms 단위) [wait=0]
+ * @param config.invoke_edge 함수 호출 시점 [invoke_edge="trailing"]
+ * @return debounce 및 memo 처리된 함수
  *
  * @example invoke_edge 가 trailing 일 때
  * ``` jsx

--- a/src/hooks/use-debounce/useDebounce.ts
+++ b/src/hooks/use-debounce/useDebounce.ts
@@ -1,0 +1,23 @@
+import { useMemo, useRef } from 'react';
+import { debounce } from '../../utils/debounce/debounce.ts';
+
+type AnyFunc = (...args: never[]) => unknown;
+
+interface Config<T extends AnyFunc> {
+  func: T;
+  wait?: number;
+  invoke_edge: 'leading' | 'trailing';
+}
+
+export const useDebounce = <T extends AnyFunc>({ func, wait, invoke_edge }: Config<T>) => {
+  const func_ref = useRef<T>(func);
+  func_ref.current = func;
+
+  return useMemo(() => {
+    return debounce<T>({
+      func: ((...params: Parameters<T>) => func_ref.current(...params)) as T,
+      wait,
+      invoke_edge: invoke_edge,
+    });
+  }, [wait, invoke_edge]);
+};

--- a/src/hooks/use-debounce/useDebounce.ts
+++ b/src/hooks/use-debounce/useDebounce.ts
@@ -9,6 +9,59 @@ interface Config<T extends AnyFunc> {
   invoke_edge: 'leading' | 'trailing';
 }
 
+/**
+ * 주어진 콜백 함수에 debounce 효과를 적용하여 리턴 합니다.
+ * 생성된 함수는 지정된 지연 시간(wait) 동안 추가 호출이 없을 때까지 함수(func)의 실행을 지연 시킵니다.
+ *
+ * invoke_edge 로 함수의 호출 시점을 지정 할 수 있습니다.
+ * "trailing" 일 경우, 가장 마지막 호출 시점으로부터 지연 시간이 모두 흐른 뒤에 함수가 호출 됩니다.
+ * "leading" 일 경우 함수를 즉시 호출하고, 지연 시간동안 추가적인 호출을 차단합니다.
+ *
+ * 한편, 리턴된 함수는 memoized 되어 있습니다.
+ *
+ * @param func {Function} - 지연 효과를 적용할 함수
+ * @param wait {number} - [wait=0] 지연 시간(ms 단위)
+ * @param invoke_edge {"leading" | "trailing"} - [invoke_edge="trailing"] 함수 호출 시점.
+ * leading 일 경우 지연 시작 지점에 함수를 호출 합니다.
+ * trailing 일 경우
+ *
+ * @example invoke_edge 가 trailing 일 때
+ * ``` jsx
+ *   // invoke_edge 가 "trailing" 일 경우, 마지막 호출로 부터 300ms 후... 서버에 양식 데이터가 제출 됩니다.(기본값)
+ *   const handleSubmit = useDebounce({
+ *     func: (values: FormData) => {
+ *       // form data 를 서버에 제출 합니다
+ *     },
+ *     wait: 300,
+ *   })
+ *
+ *   //
+ *   return (
+ *     <form onSubmit={handleSubmit}>
+ *       ...
+ *     </form>
+ *   )
+ * ```
+ *
+ * @example invoke_edge 가 "leading" 일 때
+ * ``` jsx
+ *   // invoke_edge 가 "leading" 일 경우, 즉시 서버에 양식 데이터를 제출하고 이후의 호출은 300ms가 지나기 전까지 차단 됩니다.
+ *   const handleSubmit = useDebounce({
+ *     func: (values: FormData) => {
+ *       // form data 를 서버에 제출 합니다
+ *     },
+ *     wait: 300,
+ *     invoke_edge: "leading"
+ *   })
+ *
+ *   //
+ *   return (
+ *     <form onSubmit={handleSubmit}>
+ *       ...
+ *     </form>
+ *   )
+ * ```
+ */
 export const useDebounce = <T extends AnyFunc>({ func, wait, invoke_edge }: Config<T>) => {
   const func_ref = useRef<T>(func);
   func_ref.current = func;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export { useIsMounted } from './hooks/use-is-mounted/useIsMounted';
 export { useCountDownTimer } from './hooks/use-countdown-timer/useCountDownTimer';
 export { useIsomorphicLayoutEffect } from './hooks/use-isomorphic-layout-effect/useIsomorphicLayoutEffect';
 export { usePreloadImage } from './hooks/use-preload-image/usePreloadImage';
+export { useDebounce } from './hooks/use-debounce/useDebounce';
 
 // Utils
 export { createArray } from './utils/create-array/createArray';
@@ -14,3 +15,4 @@ export { delay } from './utils/delay/delay';
 export { isIos } from './utils/is-ios/isIos';
 export { isAndroid } from './utils/is-android/isAndroid';
 export { compressImage } from './utils/compress-image/compressImage';
+export { debounce } from './utils/debounce/debounce';

--- a/src/utils/debounce/debounce.test.ts
+++ b/src/utils/debounce/debounce.test.ts
@@ -1,0 +1,94 @@
+import { debounce } from './debounce';
+import { afterAll, beforeAll, beforeEach } from 'vitest';
+
+vi.useFakeTimers();
+
+describe('debounce', () => {
+  const wait = 100;
+  let func = vi.fn();
+
+  beforeAll(() => {
+    vi.useFakeTimers();
+  });
+
+  beforeEach(() => {
+    func = vi.fn();
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  it('invokeEdge 가 "trailing" 일 경우, 지연 시간(wait)만큼 함수 호출을 지연 합니다', () => {
+    const debounced_func = debounce({
+      func,
+      wait,
+      invoke_edge: 'trailing',
+    });
+
+    debounced_func();
+    expect(func).not.toHaveBeenCalled();
+
+    // 100 ms 경과
+    vi.advanceTimersByTime(wait);
+    expect(func).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokeEdge 가 "trailing" 일 경우, 지연 시간(wait) 내에 함수 호출이 발생 할 때 지연 timer 를 리셋 합니다', () => {
+    const debounced_func = debounce({
+      func,
+      wait,
+      invoke_edge: 'trailing',
+    });
+
+    debounced_func();
+    expect(func).not.toHaveBeenCalled();
+
+    for (let i = 0; i < 10; i++) {
+      // 지연 시간 내 함수 호출 발생
+      vi.advanceTimersByTime(50);
+      debounced_func();
+    }
+
+    // timer 가 리셋 되었으므로 함수 호출이 발생 하지 않음
+    expect(func).not.toHaveBeenCalled();
+
+    // 마지막 함수 호출로 부터 지연시간만큼 지난 시점이므로 함수 호출
+    vi.advanceTimersByTime(wait);
+    expect(func).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokeEdge 가 "leading" 일 경우, 호출 즉시 함수가 실행 됩니다.', () => {
+    const debouncedFunc = debounce({
+      func,
+      wait,
+      invoke_edge: 'leading',
+    });
+
+    debouncedFunc();
+    expect(func).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokeEdge 가 "leading" 일 때, 최초 호출 이후 지연 시간 내에 함수 호출이 발생 할 때 지연 timer 를 리셋 합니다', () => {
+    const debounced_func = debounce({
+      func,
+      wait,
+      invoke_edge: 'leading',
+    });
+
+    debounced_func();
+    expect(func).toHaveBeenCalledTimes(1);
+
+    for (let i = 0; i < 10; i++) {
+      // 지연 시간 내 함수 호출 발생
+      vi.advanceTimersByTime(50);
+      debounced_func();
+    }
+
+    // 마지막 호출로 부터 지연 시간 만큼 경과
+    vi.advanceTimersByTime(100);
+
+    debounced_func();
+    expect(func).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/utils/debounce/debounce.ts
+++ b/src/utils/debounce/debounce.ts
@@ -1,25 +1,46 @@
+/**
+ * 모든 종류의 function
+ */
 type AnyFunc = (...args: never[]) => unknown;
+/**
+ * debounce 처리 된 function
+ */
 type DebouncedFunc<T extends AnyFunc> = (...args: Parameters<T>) => void;
 
+/**
+ * debounce 설정 객체
+ */
 interface Config<T extends AnyFunc> {
+  /**
+   * debounce 처리 할 function
+   */
   func: T;
+  /**
+   * 지연 시간(ms)
+   * @defaultValue 0
+   */
   wait?: number;
+  /**
+   * 함수 호출 시점
+   * @defaultValue "trailing"
+   */
   invoke_edge?: 'leading' | 'trailing';
 }
 
 /**
- * debounce 효과가 적용된 함수를 생성합니다.
- * 생성된 함수는 지정된 지연 시간(wait) 동안 추가 호출이 없을 때까지 함수(func)의 실행을 지연 시킵니다.
+ * debounce 효과가 적용된 function 을 생성합니다.
+ * 생성된 function 은 지정된 지연 시간(wait) 동안 추가 호출이 없을 때까지
+ * 파리미터로 전달 받은 함수(func)의 실행을 지연 시킵니다.
  *
  * invoke_edge 로 함수의 호출 시점을 지정 할 수 있습니다.
  * "trailing" 일 경우, 가장 마지막 호출 시점으로부터 지연 시간이 모두 흐른 뒤에 함수가 호출 됩니다.
  * "leading" 일 경우 함수를 즉시 호출하고, 지연 시간동안 추가적인 호출을 차단합니다.
  *
- * @param func {Function} - 지연 효과를 적용할 함수
- * @param wait {number} - [wait=0] 지연 시간(ms 단위)
- * @param invoke_edge {"leading" | "trailing"} - [invoke_edge="trailing"] 함수 호출 시점.
- * leading 일 경우 지연 시작 지점에 함수를 호출 합니다.
- * trailing 일 경우
+ * @param config debounce 설정 객체
+ * @param config.func 지연 효과를 적용할 함수
+ * @param config.wait 지연 시간(ms 단위) [wait=0]
+ * @param config.invoke_edge 함수 호출 시점 [invoke_edge="trailing"]
+ * @return debounce 처리된 함수
  *
  * @example invoke_edge 가 trailing 일 때
  * ``` typescript

--- a/src/utils/debounce/debounce.ts
+++ b/src/utils/debounce/debounce.ts
@@ -1,0 +1,50 @@
+type AnyFunc = (...args: never[]) => unknown;
+type DebouncedFunc<T extends AnyFunc> = (...args: Parameters<T>) => void;
+
+interface Config<T extends AnyFunc> {
+  func: T;
+  wait?: number;
+  invoke_edge?: 'leading' | 'trailing';
+}
+
+/**
+ * debounce 효과가 적용된 함수를 생성합니다.
+ * 생성된 함수는 지정된 지연 시간(wait) 동안 추가 호출이 없을 때까지 함수(func)의 실행을 지연 시킵니다.
+ *
+ * invoke_edge 로 함수의 호출 시점을 지정 할 수 있습니다.
+ * "trailing" 일 경우, 가장 마지막 호출 시점으로부터 지연 시간이 모두 흐른 뒤에 함수가 호출 됩니다.
+ * "leading" 일 경우 함수를 즉시 호출하고, 지연 시간동안 추가적인 호출을 차단합니다.
+ *
+ * @param func {Function} - 지연 효과를 적용할 함수
+ * @param wait {number} - [wait=0] 지연 시간(ms 단위)
+ * @param invoke_edge {"leading" | "trailing"} - [invoke_edge="trailing"] 함수 호출 시점.
+ * leading 일 경우 지연 시작 지점에 함수를 호출 합니다.
+ * trailing 일 경우
+ */
+export const debounce = <T extends AnyFunc>({
+  func,
+  wait = 0,
+  invoke_edge = 'trailing',
+}: Config<T>): DebouncedFunc<T> => {
+  let timer_id: NodeJS.Timeout | undefined = undefined;
+
+  if (invoke_edge === 'leading') {
+    return (...params: Parameters<T>) => {
+      if (typeof timer_id === 'undefined') {
+        func(...params);
+      }
+      clearTimeout(timer_id);
+      timer_id = setTimeout(() => {
+        timer_id = undefined;
+      }, wait);
+    };
+  }
+
+  return (...params: Parameters<T>) => {
+    clearTimeout(timer_id);
+    timer_id = setTimeout(() => {
+      timer_id = undefined;
+      func(...params);
+    }, wait);
+  };
+};

--- a/src/utils/debounce/debounce.ts
+++ b/src/utils/debounce/debounce.ts
@@ -20,6 +20,37 @@ interface Config<T extends AnyFunc> {
  * @param invoke_edge {"leading" | "trailing"} - [invoke_edge="trailing"] 함수 호출 시점.
  * leading 일 경우 지연 시작 지점에 함수를 호출 합니다.
  * trailing 일 경우
+ *
+ * @example invoke_edge 가 trailing 일 때
+ * ``` typescript
+ *   // invoke_edge 가 "trailing" 일 경우...(기본값)
+ *   const debounced_func_trailing = debounce({
+ *     func: () => {
+ *       console.log("invoked")
+ *     },
+ *     wait: 300,
+ *   })
+ *
+ *   // 마지막 호출로 부터 300ms 후... "invoked" 1 회 출력
+ *   debounced_func_trailing()
+ *   debounced_func_trailing()
+ * ```
+ *
+ * @example invoke_edge 가 "leading" 일 때
+ * ``` typescript
+ *   // invoke_edge 가 "leading" 일 경우...
+ *   const debounced_func_leading = debounce({
+ *     func: () => {
+ *       console.log("invoked")
+ *     },
+ *     wait: 300,
+ *     invoke_edge: "leading"
+ *   })
+ *
+ *   // 즉시 "invoked" 1회 출력 후 마지막 호출로 부터 300ms 가 지나기 전까지 함수 호출 차단
+ *   debounced_func_leading()
+ *   debounced_func_leading()
+ * ```
  */
 export const debounce = <T extends AnyFunc>({
   func,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,4 @@ export { delay } from './delay/delay';
 export { isIos } from './is-ios/isIos';
 export { isAndroid } from './is-android/isAndroid';
 export { compressImage } from './compress-image/compressImage';
+export { debounce } from './debounce/debounce';


### PR DESCRIPTION
## 작업내역

debounce 처리용 util 함수와 hook 을 구현 하였습니다.

### debounce
util 로 제공되는 `debounce` 함수는 기본적으로 `lodash` 의 것과 유사하게 동작 하도록 설계 하였습니다.

``` typescript
// invoke_edge 가 "trailing" 일 경우...(기본값)
const debounced_func_trailing = debounce({
  func: () => {
    console.log("invoked")
  },
  wait: 300,
})

// 300ms 후... "invoked" 1 회 출력
debounced_func_trailing()
debounced_func_trailing()

// invoke_edge 가 leading 일 경우...
const debounced_func_leading = debounce({
  func: () => {
    console.log("invoked")
  },
  wait: 300,
  invoke_edge: "leading"
})

// 즉시 "invoked" 1회 출력
debounced_func_leading()
debounced_func_leading()
```

### useDebounce

debounce 와 동일한 옵션을 파라미터로 받도록 설계 하였습니다.
내부적으로 `useRef` 를 이용하여 콜백 함수의 ref 를 항상 fresh 한 상태로 유지 하도록 하여
클로저 스코프를 고려하지 않을 수 있게 처리 하였습니다.

``` typescript
export const useDebounce = <T>({ func, ...rest }: Config<T>) => {
  // 콜백함수 의 참조를 항상 fresh 한 상태로 유지
  const func_ref = useRef<T>(func);
  func_ref.current = func;
  ...
};
```

## 고민사항 / 중점적으로 리뷰받고 싶은 부분

현재 util 과 hook 은 동일한 타입을 중복으로 선언하여 사용하고 있습니다.
util 함수의 구현이 가 변경 되었을 때 hook 에 영향을 주지 않게 하기 위함인데요,
좀 더 좋은 방법이 있을지 의견 부탁 드립니다!

## 꼭 확인해주세요

- PR 작성자
  - 자체테스트 혹은 QA 가 완료되었나요?
  - 서버 배포 필요여부 및 배포 순서를 확인하였나요?
  - Squash merge를 해주세요
  - 리뷰 대응중인 경우 PR의 상태를 꼭 `draft`로 변경해주세요
  - 코드 설명이 필요하다 싶은 부분은 `comment`를 통해 설명을 붙여주세요
  - 테스트 코드를 테스트 하기 위해서는 `test`라벨을 붙여서 PR을 생성 해주세요
- 리뷰어
  - 꼭 반영해주었으면 하는 부분은 `request change`로 남겨주세요
  - 리뷰 전에 확인이 필요하거나 궁금한 부분은 `comment`로 남겨주세요
  - 반영되면 좋지만 꼭 반영되지 않아도 되는 코멘트인 경우에는 `approve`로 남겨주세요
