### PR TITLE
feat: 유틸함수 when 추가

### DIFF
--- a/.changeset/early-rockets-rest.md
+++ b/.changeset/early-rockets-rest.md
@@ -1,0 +1,5 @@
+---
+'@croquiscom/monolith': minor
+---
+
+when 함수 추가

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,3 +9,4 @@ export { isAndroid } from './is-android/isAndroid';
 export { compressImage } from './compress-image/compressImage';
 export { debounce } from './debounce/debounce';
 export { throttle } from './throttle/throttle';
+export { When } from './when/when';

--- a/src/utils/when/when.test.ts
+++ b/src/utils/when/when.test.ts
@@ -1,0 +1,154 @@
+import { When } from './when';
+
+describe('When', () => {
+  describe('When.create()', () => {
+    describe('조건이 매칭될 때', () => {
+      it('첫 번째로 true 인 조건의 값을 반환합니다', () => {
+        const result = When.create<string>()
+          .is(true, 'first')
+          .is(true, 'second')
+          .else('default');
+
+        expect(result).toBe('first');
+      });
+
+      it('중간 조건이 매칭될 때 해당 값을 반환합니다', () => {
+        const result = When.create<string>()
+          .is(false, 'A')
+          .is(true, 'B')
+          .is(true, 'C')
+          .else('default');
+
+        expect(result).toBe('B');
+      });
+
+      it('결과값이 0 이어도 else 기본값이 아닌 매칭된 0 을 반환합니다', () => {
+        const result = When.create<number>().is(true, 0).else(99);
+
+        expect(result).toBe(0);
+      });
+
+      it('결과값이 빈 문자열이어도 else 기본값이 아닌 매칭된 빈 문자열을 반환합니다', () => {
+        const result = When.create<string>().is(true, '').else('default');
+
+        expect(result).toBe('');
+      });
+
+      it('결과값이 false 이어도 else 기본값이 아닌 매칭된 false 를 반환합니다', () => {
+        const result = When.create<boolean>().is(true, false).else(true);
+
+        expect(result).toBe(false);
+      });
+    });
+
+    describe('조건이 매칭되지 않을 때', () => {
+      it('모든 조건이 false 일 때 else 기본값을 반환합니다', () => {
+        const result = When.create<string>()
+          .is(false, 'A')
+          .is(false, 'B')
+          .else('default');
+
+        expect(result).toBe('default');
+      });
+
+      it('.is() 가 하나도 없을 때 else 기본값을 반환합니다', () => {
+        const result = When.create<string>().else('default');
+
+        expect(result).toBe('default');
+      });
+    });
+
+    describe('실제 사용 시나리오', () => {
+      it('showroom 상태 분기에 사용할 수 있습니다', () => {
+        enum ShowroomStatus {
+          SCHEDULED = 'SCHEDULED',
+          ENDED = 'ENDED',
+          ACTIVE = 'ACTIVE',
+        }
+        const date_start = new Date('2024-01-01');
+        const date_end = new Date('2024-12-31');
+        const now_before_start = new Date('2023-06-15');
+        const now_active = new Date('2024-06-15');
+        const now_after_end = new Date('2025-03-01');
+
+        const scheduled_status = When.create<ShowroomStatus>()
+          .is(now_before_start < date_start, ShowroomStatus.SCHEDULED)
+          .is(now_before_start > date_end, ShowroomStatus.ENDED)
+          .else(ShowroomStatus.ACTIVE);
+
+        const active_status = When.create<ShowroomStatus>()
+          .is(now_active < date_start, ShowroomStatus.SCHEDULED)
+          .is(now_active > date_end, ShowroomStatus.ENDED)
+          .else(ShowroomStatus.ACTIVE);
+
+        const ended_status = When.create<ShowroomStatus>()
+          .is(now_after_end < date_start, ShowroomStatus.SCHEDULED)
+          .is(now_after_end > date_end, ShowroomStatus.ENDED)
+          .else(ShowroomStatus.ACTIVE);
+
+        expect(scheduled_status).toBe(ShowroomStatus.SCHEDULED);
+        expect(active_status).toBe(ShowroomStatus.ACTIVE);
+        expect(ended_status).toBe(ShowroomStatus.ENDED);
+      });
+    });
+  });
+
+  describe('When.of()', () => {
+    describe('subject 기반 조건이 매칭될 때', () => {
+      it('subject 를 조건 함수에 전달하여 true 를 반환하는 첫 번째 값을 반환합니다', () => {
+        const result = When.of<number, string>(85)
+          .is((s) => s >= 90, '우수')
+          .is((s) => s >= 70, '양호')
+          .else('미흡');
+
+        expect(result).toBe('양호');
+      });
+
+      it('첫 번째 조건이 매칭된 이후 나머지 조건 함수를 호출하지 않습니다', () => {
+        const second_condition = vi.fn().mockReturnValue(true);
+
+        When.of<number, string>(95)
+          .is((s) => s >= 90, '우수')
+          .is(second_condition, '양호')
+          .else('미흡');
+
+        expect(second_condition).not.toHaveBeenCalled();
+      });
+
+      it('subject 가 string 타입일 때 조건 함수에 올바른 타입으로 전달됩니다', () => {
+        const result = When.of<string, number>('hello')
+          .is((s) => s.length > 3, 1)
+          .else(0);
+
+        expect(result).toBe(1);
+      });
+    });
+
+    describe('subject 기반 조건이 매칭되지 않을 때', () => {
+      it('모든 조건 함수가 false 를 반환하면 else 기본값을 반환합니다', () => {
+        const result = When.of<number, string>(50)
+          .is((s) => s >= 90, '우수')
+          .is((s) => s >= 70, '양호')
+          .else('미흡');
+
+        expect(result).toBe('미흡');
+      });
+    });
+
+    describe('실제 사용 시나리오', () => {
+      it('점수 구간별 등급 분류에 사용할 수 있습니다', () => {
+        const getGrade = (score: number) =>
+          When.of<number, string>(score)
+            .is((s) => s >= 90, 'A')
+            .is((s) => s >= 80, 'B')
+            .is((s) => s >= 70, 'C')
+            .else('F');
+
+        expect(getGrade(95)).toBe('A');
+        expect(getGrade(85)).toBe('B');
+        expect(getGrade(75)).toBe('C');
+        expect(getGrade(60)).toBe('F');
+      });
+    });
+  });
+});

--- a/src/utils/when/when.ts
+++ b/src/utils/when/when.ts
@@ -1,0 +1,111 @@
+/**
+ * Kotlin의 `when` 표현식과 유사한 방식으로 조건에 따른 값을 결정합니다.
+ * if-else 체인과 달리 표현식(expression)으로 동작하여 `const` 할당이 가능하며,
+ * `.else()` 를 통해 기본값 처리가 강제됩니다.
+ *
+ * - `When.create()` — 조건마다 참조 대상이 다를 때 boolean 조건으로 사용합니다.
+ * - `When.of(subject)` — 하나의 변수를 기준으로 분기할 때 사용합니다.
+ *
+ * @example When.create() 기본 사용
+ * ```typescript
+ * enum ShowroomStatus { SCHEDULED, ENDED, ACTIVE }
+ *
+ * const status = When.create<ShowroomStatus>()
+ *   .is(now < dateStart, ShowroomStatus.SCHEDULED)
+ *   .is(now > dateEnd,   ShowroomStatus.ENDED)
+ *   .else(ShowroomStatus.ACTIVE);
+ * ```
+ *
+ * @example When.of() 기본 사용 — 단일 변수 기준 분기
+ * ```typescript
+ * const label = When.of<number, string>(score)
+ *   .is(s => s >= 90, '우수')
+ *   .is(s => s >= 70, '양호')
+ *   .else('미흡');
+ * ```
+ *
+ * @example 어떤 조건도 매칭되지 않을 때 else 기본값 반환
+ * ```typescript
+ * const result = When.create<string>()
+ *   .is(false, 'A')
+ *   .is(false, 'B')
+ *   .else('기본값'); // '기본값' 반환
+ * ```
+ *
+ * @example falsy 값(0, false, 빈 문자열)도 결과값으로 사용 가능
+ * ```typescript
+ * const count = When.create<number>()
+ *   .is(isEmpty, 0)
+ *   .else(items.length);
+ * ```
+ */
+export class When<TResult, TSubject = void> {
+  private is_matched = false;
+  private result!: TResult;
+
+  private constructor(private readonly subject: TSubject) {}
+
+  /**
+   * 조건마다 참조 대상이 다를 때 boolean 조건으로 When 빌더를 생성합니다.
+   * @returns When 빌더 인스턴스
+   *
+   * @example
+   * ```typescript
+   * const status = When.create<ShowroomStatus>()
+   *   .is(now < dateStart, ShowroomStatus.SCHEDULED)
+   *   .is(now > dateEnd,   ShowroomStatus.ENDED)
+   *   .else(ShowroomStatus.ACTIVE);
+   * ```
+   */
+  static create<TResult>(): When<TResult, void> {
+    return new When<TResult, void>(undefined as void);
+  }
+
+  /**
+   * 하나의 변수(subject)를 기준으로 분기할 때 When 빌더를 생성합니다.
+   * @param subject 조건 함수에 전달될 대상 값
+   * @returns When 빌더 인스턴스
+   *
+   * @example
+   * ```typescript
+   * const label = When.of<number, string>(score)
+   *   .is(s => s >= 90, '우수')
+   *   .is(s => s >= 70, '양호')
+   *   .else('미흡');
+   * ```
+   */
+  static of<TSubject, TResult>(subject: TSubject): When<TResult, TSubject> {
+    return new When<TResult, TSubject>(subject);
+  }
+
+  /**
+   * 조건이 true 일 때 반환할 값을 등록합니다.
+   * 이미 이전 조건이 매칭된 경우 이후 조건은 평가하지 않습니다.
+   * @param condition `When.create()` 에서는 `boolean`, `When.of()` 에서는 subject 를 받는 함수
+   * @param value 조건이 true 일 때 반환할 값
+   * @returns 체이닝을 위한 When 인스턴스
+   */
+  is(condition: TSubject extends void ? boolean : (s: TSubject) => boolean, value: TResult): this {
+    if (!this.is_matched) {
+      const matched =
+        typeof condition === 'function'
+          ? (condition as (s: TSubject) => boolean)(this.subject)
+          : (condition as boolean);
+
+      if (matched) {
+        this.is_matched = true;
+        this.result = value;
+      }
+    }
+    return this;
+  }
+
+  /**
+   * 어떤 조건도 매칭되지 않았을 때 반환할 기본값을 지정하고 최종 결과를 반환합니다.
+   * @param value 기본 반환값
+   * @returns 매칭된 값 또는 기본값
+   */
+  else(value: TResult): TResult {
+    return this.is_matched ? this.result : value;
+  }
+}

--- a/src/utils/when/when.ts
+++ b/src/utils/when/when.ts
@@ -40,7 +40,7 @@
  * ```
  */
 export class When<TResult, TSubject = void> {
-  private is_matched = false;
+  private isMatched = false;
   private result!: TResult;
 
   private constructor(private readonly subject: TSubject) {}
@@ -86,18 +86,22 @@ export class When<TResult, TSubject = void> {
    * @returns 체이닝을 위한 When 인스턴스
    */
   is(condition: TSubject extends void ? boolean : (s: TSubject) => boolean, value: TResult): this {
-    if (!this.is_matched) {
-      const matched =
+    if (this.isMatched) {
+      return this;
+    }
+
+    const matched =
         typeof condition === 'function'
           ? (condition as (s: TSubject) => boolean)(this.subject)
           : (condition as boolean);
 
       if (matched) {
-        this.is_matched = true;
+        this.isMatched = true;
         this.result = value;
       }
-    }
+      
     return this;
+    
   }
 
   /**
@@ -106,6 +110,6 @@ export class When<TResult, TSubject = void> {
    * @returns 매칭된 값 또는 기본값
    */
   else(value: TResult): TResult {
-    return this.is_matched ? this.result : value;
+    return this.isMatched ? this.result : value;
   }
 }


### PR DESCRIPTION
 ---
  ## 작업내역

  `When` 유틸을 추가했습니다.

  TypeScript에서 조건에 따라 값을 결정하는 패턴을 Kotlin의 `when` 표현식처럼 표현식(expression)으로 사용할 수 있도록 체이닝 빌더를 구현했습니다.

  ### 배경 — 어떤 점이 불편했나요?

  `if-else`와 `switch`는 **문(statement)** 이기 때문에 `const`에 직접 할당할 수 없고, 선언과 할당이 분리됩니다.

  ```typescript
  // ❌ let 사용 강제, 선언과 할당 분리
  let status: ShowroomStatus;
  if (now < dateStart) {
    status = ShowroomStatus.SCHEDULED;
  } else if (now > dateEnd) {
    status = ShowroomStatus.ENDED;
  } else {
    status = ShowroomStatus.ACTIVE;
  }

  // ❌ switch(true) — 의도 불명확, default 누락 시 컴파일 통과
  switch (true) {
    case now < dateStart: status = ShowroomStatus.SCHEDULED; break;
    case now > dateEnd:   status = ShowroomStatus.ENDED;     break;
    // default 없어도 에러 없음 → undefined 위험
  }
  ```
  ### 왜 When을 생각했나요?

  Kotlin의 when 표현식에서 영감을 받았습니다.

  // Kotlin — when은 표현식, 바로 변수에 할당 가능
``` kotiln
  val status = when {
    now.isBefore(dateStart) -> ShowroomStatus.SCHEDULED
    now.isAfter(dateEnd)    -> ShowroomStatus.ENDED
    else                    -> ShowroomStatus.ACTIVE
  }
```

  TypeScript에 동일한 문법이 없기 때문에 체이닝 빌더 패턴으로 같은 의도를 표현할 수 있는 When 유틸을 추가했습니다.

  ### 어떤 장점이 있나요?


<img width="822" height="240" alt="스크린샷 2026-04-13 오후 6 34 18" src="https://github.com/user-attachments/assets/7d5eee0b-9772-4493-9ebd-18bfa81678ca" />


  ### 두 가지 모드를 제공합니다.
  - When.create() — 조건마다 참조 대상이 다를 때 (boolean 직접 전달)
  - When.of(subject) — 하나의 변수 기준으로 분기할 때 (subject를 조건 함수에 전달, 반복 제거)

 ###  사용 예시

  When.create() — Showroom 상태 분기
```tsx
  // Before
  let status: ShowroomStatus;
  if (now < dateStart) {
    status = ShowroomStatus.SCHEDULED;
  } else if (now > dateEnd) {
    status = ShowroomStatus.ENDED;
  } else {
    status = ShowroomStatus.ACTIVE;
  }

  // After
  const status = When.create<ShowroomStatus>()
    .is(now < dateStart, ShowroomStatus.SCHEDULED)
    .is(now > dateEnd,   ShowroomStatus.ENDED)
    .else(ShowroomStatus.ACTIVE);
```

  When.of() — 단일 변수 기준 분기

```tsx
  // Before
  let label: string;
  if (score >= 90) {
    label = '우수';
  } else if (score >= 70) {
    label = '양호';
  } else {
    label = '미흡';
  }

  // After
  const label = When.of<number, string>(score)
    .is(s => s >= 90, '우수')
    .is(s => s >= 70, '양호')
    .else('미흡');
```
  고민사항 / 중점적으로 리뷰받고 싶은 부분

  - When.create() / When.of() 두 모드를 하나의 클래스로 통합했는데, 분리하는 것이 더 나을지 의견 부탁드립니다.
  - .is() 조건 타입을 TSubject extends void ? boolean : (s: TSubject) => boolean 으로 분기했는데 더 나은 타입 표현이 있다면 제안해 주세요.

- PR 작성자
  - 자체테스트 혹은 QA 가 완료되었나요?
  - 서버 배포 필요여부 및 배포 순서를 확인하였나요?
  - Squash merge를 해주세요
  - 리뷰 대응중인 경우 PR의 상태를 꼭 `draft`로 변경해주세요
  - 코드 설명이 필요하다 싶은 부분은 `comment`를 통해 설명을 붙여주세요
  - 테스트 코드를 테스트 하기 위해서는 `test`라벨을 붙여서 PR을 생성 해주세요
- 리뷰어
  - 꼭 반영해주었으면 하는 부분은 `request change`로 남겨주세요
  - 리뷰 전에 확인이 필요하거나 궁금한 부분은 `comment`로 남겨주세요
  - 반영되면 좋지만 꼭 반영되지 않아도 되는 코멘트인 경우에는 `approve`로 남겨주세요
